### PR TITLE
chore: remove unused import

### DIFF
--- a/ep05_CMS_Dimuons.ipynb
+++ b/ep05_CMS_Dimuons.ipynb
@@ -198,7 +198,6 @@
       "source": [
         "import numpy as np\n",
         "import h5py\n",
-        "import awkward as ak\n",
         "import matplotlib.pyplot as plt\n",
         "import mplhep as hep"
       ],


### PR DESCRIPTION
Remove `import awkward as ak`